### PR TITLE
[update]改进冒泡法写法

### DIFF
--- a/maopao/index.go
+++ b/maopao/index.go
@@ -2,7 +2,7 @@ package maopao
 // 冒泡排序并输出结果。
 func numb(a []int64){
     for i := 0; i < len(a) -1; i ++ {
-        for j := 0; j < len(a)-1;j ++ {
+        for j := 0; j < len(a)-1-i;j ++ {
                if a[j] >= a [j+1] {
             a[j+1],a[j] = a[j],a[j+1]
         


### PR DESCRIPTION
内部的循环应该是每次都减少一个i，因为随着排序应该是一次比一次少的数据。